### PR TITLE
Fix Authorization header having "null" value after logout

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -45,8 +45,10 @@ const logout = evt => {
 
 const getUsers = evt => {
   evt.preventDefault()
+  const token = localStorage.getItem('token')
+
   fetch(`/api/users`, {
-    headers: { 'Authorization': localStorage.getItem('token') },
+    headers: token ? { 'Authorization': token } : {},
   })
     .then(res => {
       return res.json()


### PR DESCRIPTION
When token isn't present in localStorage (i.e. client is logged out), the client is sending the string "null" in Authorization header. The client should not send an Authorization header if there is no token. This would allow the server to skip the token verification step in the middleware.

See `restricted-middleware.js` for reference:
https://github.com/LambdaSchool/node-auth2-guided/blob/lecture/api/auth/restricted-middleware.js#L7